### PR TITLE
Improvements

### DIFF
--- a/argo.sh
+++ b/argo.sh
@@ -21,6 +21,9 @@ spinner() {
 }
 
 install_service() {
+    if ! command -v qrencode &>/dev/null; then
+        apt install -y qrencode
+    fi
     if ! command -v cloudflared &>/dev/null; then
 
         echo "Downloading Cloudflare Argo Tunnel binary..."
@@ -37,7 +40,7 @@ install_service() {
     spinner $!
     echo "Authentication successful."
 
-    read -p "Enter your desired config port: " user_port
+    read -p "Enter your desired config port [Use 443 when possible]: " user_port
     read -p "Enter your desired Tunnel name: " user_tunnelname
     read -p "Enter your desired subdomain (e.g., sub.mydomain.com): " user_subdomain
     uuid=$(cat /proc/sys/kernel/random/uuid)


### PR DESCRIPTION
The script installs `qrencode` on apt-based systems like Ubuntu and Debian.

Hints the user to use tcp/443 for tunnel when it's not already in use.